### PR TITLE
fix: Do not trigger failure mechanism if scene is already reloading

### DIFF
--- a/scenes/levels/BasicLevel.gd
+++ b/scenes/levels/BasicLevel.gd
@@ -7,7 +7,8 @@ class_name BasicLevel
 @export var intro: AudioStream
 
 var player: Player
-var _chests_to_open = 0
+var _chests_to_open := 0
+var _has_failed := false
 
 func _ready():
 	SaveController.update_progression(get_tree().current_scene)
@@ -69,18 +70,17 @@ func is_level_completed() -> bool:
 	return _chests_to_open == 0
 
 func _on_player_caught_by_camera():
-	player.onCatch()
-	await get_tree().create_timer(0.2).timeout
 	_you_failed()
 
 func _on_player_caught_by_guard():
-	player.onCatch()
-	await get_tree().create_timer(0.2).timeout
 	_you_failed()
 
 func _you_failed():
-	await get_tree().create_timer(0.3).timeout
-	const youFailedScene = preload("res://scenes/YouFailed.tscn")
-	add_child(youFailedScene.instantiate())
-	await get_tree().create_timer(.5).timeout
-	get_tree().reload_current_scene()
+	if not _has_failed:
+		_has_failed = true
+		player.onCatch()
+		await get_tree().create_timer(0.3).timeout
+		const youFailedScene = preload("res://scenes/YouFailed.tscn")
+		add_child(youFailedScene.instantiate())
+		await get_tree().create_timer(.5).timeout
+		get_tree().reload_current_scene()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Avec un mauvais timing (thème de la game jam) tu peux déclencher `_you_failed()` au moment où la scène est en train de se recharger. Ça va crasher le jeu car "Cannot call method 'create_timer' on a null value".

## Description

Ajout d'une variable à `BasicLevel` pour savoir si le niveau est déjà en train de gérer un `_you_failed()`.

## How has this been tested?

Testé à la main 😓 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.