### PR TITLE
fix: Don't play door audio at startup

### DIFF
--- a/objects/EndGate.gd
+++ b/objects/EndGate.gd
@@ -13,12 +13,13 @@ func _ready():
 	finish_shape.disabled = true
 
 
-func open():
+func open(with_sound: bool):
 	await get_tree().create_timer(0.8).timeout
 	animated_sprite.play("open")
 	finish_shape.disabled = false
 	collision_gate.disabled = true
-	unlock_door.play()
+	if with_sound:
+		unlock_door.play()
 
 
 func _on_finish_body_entered(body):

--- a/scenes/levels/BasicLevel.gd
+++ b/scenes/levels/BasicLevel.gd
@@ -55,11 +55,11 @@ func _init_guards():
 	var guards = get_tree().get_nodes_in_group("guards")
 	for guard in guards:
 		guard.on_player_catch.connect(_on_player_caught_by_guard)
-		
+
 func _init_end_gate():
 	end_gate.finish_body_entered.connect(_finish_entered)
 	if is_level_completed():
-		_try_open_end_gate()
+		_try_open_end_gate(false)
 
 func _finish_entered(body):
 	if is_level_completed() and body is Player:
@@ -69,7 +69,7 @@ func _finish_entered(body):
 
 func _on_chest_opened():
 	_chests_to_open -= 1
-	_try_open_end_gate()
+	_try_open_end_gate(true)
 
 func is_level_completed() -> bool:
 	return _chests_to_open == 0
@@ -89,7 +89,7 @@ func _you_failed():
 		add_child(youFailedScene.instantiate())
 		await get_tree().create_timer(.5).timeout
 		get_tree().reload_current_scene()
-		
-func _try_open_end_gate():
-	if is_level_completed() and end_gate != null:
-		end_gate.open()
+
+func _try_open_end_gate(with_sound: bool):
+	if is_level_completed():
+		end_gate.open(with_sound)


### PR DESCRIPTION
## Motivation and Context

When there are no chests, the door makes sound while intro is playing.

## How has this been tested?

I've started all levels.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.