### PR TITLE
fix: set import filter to nearest instead of linear

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -84,6 +84,7 @@ activate={
 
 [rendering]
 
+textures/canvas_textures/default_texture_filter=0
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
 environment/defaults/default_clear_color=Color(0, 0, 0, 1)


### PR DESCRIPTION
## Motivation and Context

There was some graphic artefact on top of thief because of texture filter we used `linear` which is not suited to pixel art assets.

## How has this been tested?

Move to left or right and see the small horizontal line above the head of thief.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.